### PR TITLE
Put resolved path for load-themed-styles.

### DIFF
--- a/src/LoadThemedStylesLoader.ts
+++ b/src/LoadThemedStylesLoader.ts
@@ -1,10 +1,11 @@
 let loaderUtils = require('loader-utils');
+let loadedThemedStylesPath = require.resolve('load-themed-styles');
 
 export class LoadThemedStylesLoader {
   public static pitch(remainingRequest: string): string {
     return [
       `var content = require(${loaderUtils.stringifyRequest(this, '!!' + remainingRequest)});`,
-      'var loader = require("load-themed-styles");',
+      `var loader = require(${JSON.stringify(loadedThemedStylesPath)});`,
       '',
       'if(typeof content === "string") content = [[module.id, content]];',
       '',


### PR DESCRIPTION
The dependent project does not need to declare `load-themed-styles` as its dependencies.

_I am doing the same thing in gulp-core-build-sass project. See https://github.com/dzearing/gulp-core-build-sass/pull/15_
